### PR TITLE
fix BuildLZO on cmake 4.x

### DIFF
--- a/BuildLZO/build.sh
+++ b/BuildLZO/build.sh
@@ -27,7 +27,8 @@ cmake -G Xcode -B build \
     -DCMAKE_SYSTEM_NAME=iOS \
     -DCMAKE_SYSTEM_PROCESSOR=aarch64 \
     -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 \
-    -DCMAKE_OSX_SYSROOT="${IOS_SYSROOT}"
+    -DCMAKE_OSX_SYSROOT="${IOS_SYSROOT}" \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 
 xcodebuild build \
     -project build/lzo.xcodeproj \


### PR DESCRIPTION
CMake (4.x) removed compatibility shims for < 3.5, so a CMakeLists.txt that declares something like cmake_minimum_required(VERSION 2.8) now fails with the message:

```
cmake -G Xcode -B build -DCMAKE_INSTALL_PREFIX=~/www/BuildVNCServer/BuildLZO/lzo-2.10/../output -DBUILD_SHARED_LIBS=OFF -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 -DCMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk
CMake Error at CMakeLists.txt:11 (cmake_minimum_required):
Compatibility with CMake < 3.5 has been removed from CMake.
Update the VERSION argument <min> value. Or, use the <min>...<max> syntax to tell CMake that the project requires at least <min> but has been updated to work with policies introduced by <max> or earlier. Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway. -- Configuring incomplete, errors occurred!
```

`BuildLZO/lzo-2.10/CMakeLists.txt` contains:
```
cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
```